### PR TITLE
Add forbid closed indeces

### DIFF
--- a/elasticsearch-head/app.js
+++ b/elasticsearch-head/app.js
@@ -1471,7 +1471,7 @@
                 updateModel.call(self);
             });
 
-            this.cluster.get("_stats", function (data) {
+            this.cluster.get("_stats?forbid_closed_indices=false", function (data) {
                 status = data;
                 updateModel.call(self);
             });
@@ -5021,7 +5021,7 @@
             this.update();
         },
         update: function () {
-            this.cluster.get("_stats", this._update_handler);
+            this.cluster.get("_stats?forbid_closed_indices=false", this._update_handler);
         },
 
         _update_handler: function (data) {


### PR DESCRIPTION
Link for thread in elastic https://github.com/elastic/elasticsearch/issues/88752

On ES 7.17.24 request to _stats failed with error:
```
{
    "error": {
        "root_cause": [
            {
                "type": "index_closed_exception",
                "reason": "closed",
                "index_uuid": "Q2JS4jIXRyCsI9k_7RnK5w",
                "index": "closedIndexName"
            }
        ],
        "type": "index_closed_exception",
        "reason": "closed",
        "index_uuid": "Q2JS4jIXRyCsI9k_7RnK5w",
        "index": "closedIndexName"
    },
    "status": 400
}
```

So it needed to send `?forbid_closed_indices=false`